### PR TITLE
[JENKINS-37154] Timeout fixes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.Timer;
@@ -228,7 +229,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         try {
             getPauseAction().remove(this);
             run.save();
-        } catch (IOException x) {
+        } catch (IOException | InterruptedException | TimeoutException x) {
             LOGGER.log(Level.WARNING, "failed to remove InputAction from " + run, x);
         } finally {
             if (node != null) {


### PR DESCRIPTION
Amends #1. That caused `WorkflowPluginTest.linearFlow` to fail sometimes. The reason was that the test as written restarted Jenkins and then immediately clicked the _Proceed_ link, without waiting for the agent to come back online. Since the flow execution does not resume until the agent is ready, which takes some time (tries to reconnect at intervals), the `proceed` REST API could easily hit the short (10s) timeout @svanoort talked me into against my best judgment. At that point not only did the initial click not work, but the `input` step could not be submitted even _after_ the build resumed (not that the test tried).

Applying the patch considered in #1, making the timeout be for each request individually, and increasing the timeout to reflect the fact that reality is messy and it is better to just wait a little while than fail.

(The root problem here is that in the test, `input` is inside `node`—perfectly legal, if not usually recommended due to the executor lock—and the way @kohsuke designed the pickle system, it is not possible to run any continuations until every pickle is rehydrated. In this case `ExecutorPickle` and others block until the slave reattaches, so the whole build is frozen, even though `input` does not care about the objects being pickled: it is not until the `step` one line later in the script that we actually need them. My counterproposal was that `program.dat` should not even claim to store live objects like `Executor`, but rather special `Serializable` objects representing similar information, like the `slave` and `path` in `WorkspaceListLeasePickle`; and `StepExecution` code would be responsible for using this information however it liked, for example by printing progress messages about offline agents, attaching `ListenableFuture` callbacks, etc. @kohsuke rejected this design, so we are stuck with cases like this where program metadata is unavailable until some indeterminate future time, and callers need to adapt as best they can.)

@reviewbybees esp. @svanoort