### PR TITLE
[WIP] Add new API to store input parameter info separately from the execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputAction.java
@@ -7,8 +7,11 @@ import jenkins.model.RunAction2;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -33,15 +36,33 @@ public class InputAction implements RunAction2 {
 
     private transient Run<?,?> run;
 
+    /** ID to InputPromptDefinition */
+    private Map<String,InputPromptDefinition> inputDefinitions;
+
+    private transient ReadWriteLock lock = new ReentrantReadWriteLock();
+
     @Override
     public void onAttached(Run<?, ?> r) {
         this.run = r;
     }
 
+    public Map<String, InputPromptDefinition> getInputDefinitions() {
+        try {
+            lock.readLock().lock();
+            if (inputDefinitions == null) {
+                loadExecutions();
+            }
+            return inputDefinitions;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     @Override
     public void onLoad(Run<?, ?> r) {
         this.run = r;
-        synchronized (this) {
+        try {
+            lock.readLock().lock();
             if (ids == null) {
                 // Loading from before JENKINS-25889 fix. Load the IDs and discard the executions, which lack state anyway.
                 assert executions != null && !executions.contains(null) : executions;
@@ -51,40 +72,49 @@ public class InputAction implements RunAction2 {
                 }
                 executions = null;
             }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
     @SuppressFBWarnings(value="EC_UNRELATED_TYPES_USING_POINTER_EQUALITY", justification="WorkflowRun implements Queue.Executable")
-    private synchronized void loadExecutions() {
-        if (executions == null) {
-            executions = new ArrayList<InputStepExecution>();
-            try {
-            FlowExecution execution = null;
-            for (FlowExecution _execution : FlowExecutionList.get()) {
-                if (_execution.getOwner().getExecutable() == run) {
-                    execution = _execution;
-                    break;
-                }
-            }
-            if (execution != null) {
-                // JENKINS-37154 sometimes we must block here in order to get accurate results
-                for (StepExecution se : execution.getCurrentExecutions(true).get(LOAD_EXECUTIONS_TIMEOUT, TimeUnit.SECONDS)) {
-                    if (se instanceof InputStepExecution) {
-                        InputStepExecution ise = (InputStepExecution) se;
-                        if (ids.contains(ise.getId())) {
-                            executions.add(ise);
+    private void loadExecutions() {
+        try {
+            lock.readLock().lock(); // Might not be necessary
+            if (executions == null) {
+                lock.writeLock().lock();
+                executions = new ArrayList<InputStepExecution>();
+                try {
+                    FlowExecution execution = null;
+                    for (FlowExecution _execution : FlowExecutionList.get()) {
+                        if (_execution.getOwner().getExecutable() == run) {
+                            execution = _execution;
+                            break;
                         }
                     }
+                    if (execution != null) {
+                        // JENKINS-37154 sometimes we must block here in order to get accurate results
+                        for (StepExecution se : execution.getCurrentExecutions(true).get(LOAD_EXECUTIONS_TIMEOUT, TimeUnit.SECONDS)) {
+                            if (se instanceof InputStepExecution) {
+                                InputStepExecution ise = (InputStepExecution) se;
+                                if (ids.contains(ise.getId())) {
+                                    executions.add(ise);
+                                }
+                            }
+                        }
+                        if (executions.size() < ids.size()) {
+                            LOGGER.log(Level.WARNING, "some input IDs not restored from {0}", run);
+                        }
+                    } else {
+                        LOGGER.log(Level.WARNING, "no flow execution found for {0}", run);
+                    }
+                } catch (Exception x) {
+                    LOGGER.log(Level.WARNING, null, x);
                 }
-                if (executions.size() < ids.size()) {
-                    LOGGER.log(Level.WARNING, "some input IDs not restored from {0}", run);
-                }
-            } else {
-                LOGGER.log(Level.WARNING, "no flow execution found for {0}", run);
             }
-            } catch (Exception x) {
-                LOGGER.log(Level.WARNING, null, x);
-            }
+        } finally {
+            lock.readLock().unlock();
+            lock.writeLock().unlock();
         }
     }
 
@@ -115,35 +145,55 @@ public class InputAction implements RunAction2 {
         return "input";
     }
 
-    public synchronized void add(@Nonnull InputStepExecution step) throws IOException {
-        loadExecutions();
-        this.executions.add(step);
-        ids.add(step.getId());
-        run.save();
+    public void add(@Nonnull InputStepExecution step) throws IOException {
+        try {
+            loadExecutions();
+            lock.writeLock().lock();
+            this.executions.add(step);
+            ids.add(step.getId());
+            run.save();
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public synchronized InputStepExecution getExecution(String id) {
-        loadExecutions();
-        for (InputStepExecution e : executions) {
-            if (e.input.getId().equals(id))
-                return e;
+        try {
+            lock.readLock().lock();
+            loadExecutions();
+            for (InputStepExecution e : executions) {
+                if (e.input.getId().equals(id))
+                    return e;
+            }
+            return null;
+        } finally {
+            lock.readLock().unlock();
         }
-        return null;
     }
 
-    public synchronized List<InputStepExecution> getExecutions() {
-        loadExecutions();
-        return new ArrayList<InputStepExecution>(executions);
+    public List<InputStepExecution> getExecutions() {
+        try {
+            lock.readLock().lock();
+            loadExecutions();
+            return new ArrayList<InputStepExecution>(executions);
+        } finally {
+            lock.writeLock().lock();
+        }
     }
 
     /**
      * Called when {@link InputStepExecution} is completed to remove it from the active input list.
      */
-    public synchronized void remove(InputStepExecution exec) throws IOException {
-        loadExecutions();
-        executions.remove(exec);
-        ids.remove(exec.getId());
-        run.save();
+    public void remove(InputStepExecution exec) throws IOException {
+        try {
+            loadExecutions();
+            lock.writeLock().lock();
+            executions.remove(exec);
+            ids.remove(exec.getId());
+            run.save();
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
@@ -17,7 +17,6 @@ public class InputPromptDefinition {
 
     private String submitter;
 
-
     private List<ParameterDefinition> parameters = Collections.emptyList();
 
     private String ok;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
@@ -1,0 +1,98 @@
+package org.jenkinsci.plugins.workflow.support.steps.input;
+
+import hudson.Util;
+import hudson.model.ParameterDefinition;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Holds the information needed to query for input
+ */
+public class InputPromptDefinition {
+    private final String message;
+
+    private String id;
+
+    private String submitter;
+
+
+    private List<ParameterDefinition> parameters = Collections.emptyList();
+
+    private String ok;
+
+    public InputPromptDefinition(String message) {
+        this.message = message;
+    }
+
+    public InputPromptDefinition(InputStep st) {
+        this.message = st.getMessage();
+        this.id = st.getId();
+        this.parameters = st.getParameters();
+        this.ok = st.getId();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    // TODO pull this and InputStep version out to common function
+    private String capitalize(String id) {
+        if (id==null)
+            return null;
+        if (id.length()==0)
+            throw new IllegalArgumentException();
+        // a-z as the first char is reserved for InputAction
+        char ch = id.charAt(0);
+        if ('a'<=ch && ch<='z')
+            id = ((char)(ch-'a'+'A')) + id.substring(1);
+        return id;
+    }
+
+    /**
+     * Optional ID that uniquely identifies this input from all others.
+     */
+    public String getId() {
+        if (id==null)
+            id = capitalize(Util.getDigestOf(message));
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Optional user/group name who can approve this.
+     */
+    public String getSubmitter() {
+        return submitter;
+    }
+
+    public void setSubmitter(String submitter) {
+        this.submitter = Util.fixEmptyAndTrim(submitter);
+    }
+
+    /**
+     * Either a single {@link ParameterDefinition} or a list of them.
+     */
+    public List<ParameterDefinition> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<ParameterDefinition> parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * Caption of the OK button.
+     */
+    public String getOk() {
+        return ok;
+    }
+
+    public void setOk(String ok) {
+        this.ok = Util.fixEmptyAndTrim(ok);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputPromptDefinition.java
@@ -36,25 +36,12 @@ public class InputPromptDefinition {
         return message;
     }
 
-    // TODO pull this and InputStep version out to common function
-    private String capitalize(String id) {
-        if (id==null)
-            return null;
-        if (id.length()==0)
-            throw new IllegalArgumentException();
-        // a-z as the first char is reserved for InputAction
-        char ch = id.charAt(0);
-        if ('a'<=ch && ch<='z')
-            id = ((char)(ch-'a'+'A')) + id.substring(1);
-        return id;
-    }
-
     /**
      * Optional ID that uniquely identifies this input from all others.
      */
     public String getId() {
         if (id==null)
-            id = capitalize(Util.getDigestOf(message));
+            id = InputStep.capitalize(Util.getDigestOf(message));
         return id;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -70,7 +70,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
         this.submitter = Util.fixEmptyAndTrim(submitter);
     }
 
-    private String capitalize(String id) {
+    static String capitalize(String id) {
         if (id==null)
             return null;
         if (id.length()==0)

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -84,7 +84,8 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     public void stop(Throwable cause) throws Exception {
         // JENKINS-37154: we might be inside the VM thread, so do not do anything which might block on the VM thread
         Timer.get().submit(new Runnable() {
-            @Override public void run() {
+            @Override
+            public void run() {
                 doAbort();
             }
         });


### PR DESCRIPTION
Very basic version of what I describe in https://github.com/jenkinsci/pipeline-input-step-plugin/pull/2#issuecomment-238959402 -- doesn't bother to move some logic to the InputAction that could be.

Attaches information about input prompts on a run to the InputAction (persistently) and provide new APIs to access it.  Since most of the external calls to the InputAction are looking to see what input is needed in order to display UI notifications, these APIs should handle this without the risk of deadlock/long wait fetching executions.  Should be faster too. 

Since older builds won't have the field, we handle null and generate generate the data from the executions when we read or modify them.

CC @jglick  to see what you think.  I'm probably missing some things here but I want to see if the idea is sound before investing more time to polish it up & test.  Should be compatible with #2 as well (just needs that merged in). 

There's some sort of small FindBugs complaint about inconsistent synchronization behavior of the run there (shrug), but that's not such a big deal at the moment.