### PR TITLE
[JENKINS-31425] should be able to specify multiple users or groups for the submitter of an input step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 work
+*.iml
+.idea

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.support.steps.input;
 
+import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.ParameterDefinition;
@@ -13,7 +14,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * {@link Step} that pauses for human input.
@@ -116,10 +119,13 @@ public class InputStep extends AbstractStepImpl implements Serializable {
      */
     @Deprecated
     public boolean canSettle(Authentication a) {
-        if (submitter==null || a.getName().equals(submitter))
+        if (submitter==null)
+            return true;
+        final Set<String> submitters = Sets.newHashSet(submitter.split(","));
+        if (submitters.contains(a.getName()))
             return true;
         for (GrantedAuthority ga : a.getAuthorities()) {
-            if (ga.getAuthority().equals(submitter))
+            if (submitters.contains(ga.getAuthority()))
                 return true;
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.support.steps.input;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import hudson.FilePath;
 import hudson.Util;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -258,13 +260,14 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
      */
     private boolean canSettle(Authentication a) {
         String submitter = input.getSubmitter();
-        if (submitter==null || a.getName().equals(submitter)) {
+        if (submitter==null)
             return true;
-        }
+        final Set<String> submitters = Sets.newHashSet(submitter.split(","));
+        if (submitters.contains(a.getName()))
+            return true;
         for (GrantedAuthority ga : a.getAuthorities()) {
-            if (ga.getAuthority().equals(submitter)) {
+            if (submitters.contains(ga.getAuthority()))
                 return true;
-            }
         }
         return false;
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
@@ -1,3 +1,3 @@
 <div>
-    User ID or <em>external</em> group name of person or people permitted to respond to the input.
+    User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, splitted by ','.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
@@ -1,3 +1,4 @@
 <div>
-    User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, splitted by ','.
+    User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, separated by ','.
+    If you configure "alice, bob", will match with "alice" but not with "bob". You need to remove all the white spaces.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -128,12 +128,9 @@ public class InputStepTest extends Assert {
         JenkinsRule.WebClient webClient = j.createWebClient();
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
-        // Only give "alice" basic privs. That's normally not enough to Job.CANCEL, only for the fact that "alice"
-        // is listed as the submitter.
-            grant(Jenkins.READ, Job.READ).everywhere().to("alice").
-        // Only give "bob" basic privs.  That's normally not enough to Job.CANCEL and "bob" is not the submitter,
-        // so they should be rejected.
-            grant(Jenkins.READ, Job.READ).everywhere().to("bob").
+        // Only give "alice" and "bob" basic privs. That's normally not enough to Job.CANCEL, only for the fact that "alice"
+        // and "bob" are listed as the submitter.
+            grant(Jenkins.READ, Job.READ).everywhere().to("alice", "bob").
         // Give "charlie" basic privs + Job.CANCEL.  That should allow user3 cancel.
             grant(Jenkins.READ, Job.READ, Job.CANCEL).everywhere().to("charlie"));
 


### PR DESCRIPTION
submitter now allows multiple users/groups separated by ','

@reviewbybees please