### PR TITLE
[FIXED JENKINS-31396] Add the submitterParameter property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -36,6 +36,11 @@ public class InputStep extends AbstractStepImpl implements Serializable {
      */
     private String submitter;
 
+    /**
+     * Optional parameter name to stored the user who responded to the input.
+     */
+    private String submitterParameter;
+
 
     /**
      * Either a single {@link ParameterDefinition} or a list of them.
@@ -71,6 +76,12 @@ public class InputStep extends AbstractStepImpl implements Serializable {
 
     @DataBoundSetter public void setSubmitter(String submitter) {
         this.submitter = Util.fixEmptyAndTrim(submitter);
+    }
+
+    public String getSubmitterParameter() { return submitterParameter; }
+
+    @DataBoundSetter public void setSubmitterParameter(String submitterParameter) {
+        this.submitterParameter = Util.fixEmptyAndTrim(submitterParameter);
     }
 
     private String capitalize(String id) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -301,14 +301,11 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
             }
         }
 
-        // If requested, add the approver to the list of returned parameters.
-        String submitter = input.getSubmitter();
-        if (submitter != null) {
+        // If a destination value is specified, push the submitter to it.
+        String valueName = input.getSubmitterParameter();
+        if (valueName != null && !valueName.isEmpty()) {
             Authentication a = Jenkins.getAuthentication();
-            String valueName = input.getSubmitterParameter();
-            if (valueName != null) {
-                mapResult.put(valueName, a.getName());
-            }
+            mapResult.put(valueName, a.getName());
         }
 
         switch (mapResult.size()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -304,9 +304,10 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         // If requested, add the approver to the list of returned parameters.
         String submitter = input.getSubmitter();
         if (submitter != null) {
+            Authentication a = Jenkins.getAuthentication();
             String valueName = input.getSubmitterParameter();
             if (valueName != null) {
-                mapResult.put(valueName, submitter);
+                mapResult.put(valueName, a.getName());
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -301,8 +301,15 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
             }
         }
 
-        // TODO: perhaps we should return a different object to allow the workflow to look up
-        // who approved it, etc?
+        // If requested, add the approver to the list of returned parameters.
+        String submitter = input.getSubmitter();
+        if (submitter != null) {
+            String valueName = input.getSubmitterParameter();
+            if (valueName != null) {
+                mapResult.put(valueName, submitter);
+            }
+        }
+
         switch (mapResult.size()) {
         case 0:
             return null;    // no value if there's no parameter

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
@@ -38,6 +38,9 @@ THE SOFTWARE.
         <f:entry field="submitter" title="Allowed Submitter">
             <f:textbox/>
         </f:entry>
+        <f:enttry field="submitterParameter" title="Parameter to store the approving submitter">
+            <f:textbox/>
+        </f:entry>
         <f:entry field="parameters" title="Parameters">
             <f:repeatableHeteroProperty field="parameters"/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
         <f:entry field="submitter" title="Allowed Submitter">
             <f:textbox/>
         </f:entry>
-        <f:enttry field="submitterParameter" title="Parameter to store the approving submitter">
+        <f:entry field="submitterParameter" title="Parameter to store the approving submitter">
             <f:textbox/>
         </f:entry>
         <f:entry field="parameters" title="Parameters">

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitterParameter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitterParameter.html
@@ -1,6 +1,6 @@
 <div>
     If specified, this is the name of the return value that will contain the ID of the user that approves this
-    input. It will only be used if submitter is specified.
+    input.
 
     The return value will be handled in a fashion similar to the <code>parameters</code> value.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitterParameter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitterParameter.html
@@ -1,0 +1,6 @@
+<div>
+    If specified, this is the name of the return value that will contain the ID of the user that approves this
+    input. It will only be used if submitter is specified.
+
+    The return value will be handled in a fashion similar to the <code>parameters</code> value.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -165,6 +165,51 @@ public class InputStepTest extends Assert {
         runAndAbort(webClient, foo, "charlie", false); // charlie shouldn't work coz he's not declared as 'submitter' and doesn't have Job.CANCEL privs
     }
 
+    @Test
+    @Issue("JENKINS-31396")
+    public void test_submitter_parameter() throws Exception {
+        //set up dummy security real
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        // job setup
+        WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
+        foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList(
+                "echo('before');",
+                "def x = input message:'Do you want chocolate?', id:'Icecream', ok: 'Purchase icecream', submitter:'alice', submitterParameter: 'approval';",
+                "echo(\"after: ${x}\");"),"\n"),true));
+
+
+        // get the build going, and wait until workflow pauses
+        QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
+        WorkflowRun b = q.getStartCondition().get();
+        CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
+
+        while (b.getAction(InputAction.class)==null) {
+            e.waitForSuspension();
+        }
+
+        // make sure we are pausing at the right state that reflects what we wrote in the program
+        InputAction a = b.getAction(InputAction.class);
+        assertEquals(1, a.getExecutions().size());
+
+        InputStepExecution is = a.getExecution("Icecream");
+        assertEquals("Do you want chocolate?", is.getInput().getMessage());
+        assertEquals("alice", is.getInput().getSubmitter());
+
+        // submit the input, and run workflow to the completion
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("alice");
+        HtmlPage p = wc.getPage(b, a.getUrlName());
+        j.submit(p.getFormByName(is.getId()), "proceed");
+        assertEquals(0, a.getExecutions().size());
+        q.get();
+
+        // make sure 'x' gets 'alice'
+        System.out.println(b.getLog());
+        String v = b.getLog();
+        System.out.println(v);
+        assertTrue(b.getLog().contains("after: alice"));
+    }
+
     private void runAndAbort(JenkinsRule.WebClient webClient, WorkflowJob foo, String loginAs, boolean expectAbortOk) throws Exception {
         // get the build going, and wait until workflow pauses
         QueueTaskFuture<WorkflowRun> queueTaskFuture = foo.scheduleBuild2(0);


### PR DESCRIPTION
Add the submitterParameter property, used to record the submitter of an input step.

It will be treated like any other parameter on the input.  If the only value returned, will be returned directly. If other parameters, will be returned with the specified name.

Intended to fix https://issues.jenkins-ci.org/browse/JENKINS-31396
