### PR TITLE
Fix the returning null value when only submitterParameter and proceeding from console output page

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -71,6 +71,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         node.addAction(new PauseAction("Input"));
 
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
+        //JENKINS-40594 submitterParameter does not work without at least one actual parameter
         if (input.getParameters().isEmpty() && (input.getSubmitterParameter() == null || input.getSubmitterParameter().isEmpty())) {
             String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -72,7 +72,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
 
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
         //JENKINS-40594 submitterParameter does not work without at least one actual parameter
-        if (input.getParameters().isEmpty() && (input.getSubmitterParameter() == null || input.getSubmitterParameter().isEmpty())) {
+        if (input.getParameters().isEmpty() && input.getSubmitterParameter() == null) {
             String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -71,7 +71,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         node.addAction(new PauseAction("Input"));
 
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
-        if (input.getParameters().isEmpty()) {
+        if (input.getParameters().isEmpty() && (input.getSubmitterParameter() == null || input.getSubmitterParameter().isEmpty())) {
             String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -167,7 +167,7 @@ public class InputStepTest extends Assert {
     }
 
     @Test
-    @Issue("JENKINS-31396")
+    @Issue({"JENKINS-31396","JENKINS-40594"})
     public void test_submitter_parameter() throws Exception {
         //set up dummy security real
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -193,6 +193,8 @@ public class InputStepTest extends Assert {
         // submit the input, and run workflow to the completion
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.login("alice");
+        HtmlPage console_page = wc.getPage(b, "console");
+        assertFalse(console_page.asXml().contains("proceedEmpty"));
         HtmlPage p = wc.getPage(b, a.getUrlName());
         j.submit(p.getFormByName(is.getId()), "proceed");
         assertEquals(0, a.getExecutions().size());


### PR DESCRIPTION
Like the below step:
...
def x = input message: 'Approve or not', submitter: 'admin,dev', submitterParameter: 'my-approval'
echo x
...
When you click "Proceed" from the console output page, "x will be null in fact, but we expect x should be admin or dev.