### PR TITLE
Fix [JENKINS-48998] by ensuring admins can always approve

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -16,6 +16,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.security.ACL;
+import hudson.security.Permission;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
@@ -282,7 +283,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     }
 
     private boolean canCancel() {
-        return getRun().getParent().hasPermission(Job.CANCEL);
+        return !Jenkins.getInstance().isUseSecurity() || getRun().getParent().hasPermission(Job.CANCEL);
     }
 
     private boolean canSubmit() {
@@ -297,6 +298,9 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String submitter = input.getSubmitter();
         if (submitter==null)
             return getRun().getParent().hasPermission(Job.BUILD);
+        if (!Jenkins.getInstance().isUseSecurity() || Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+            return true;
+        }
         final Set<String> submitters = Sets.newHashSet(submitter.split(","));
         if (submitters.contains(a.getName()))
             return true;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -283,7 +283,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     }
 
     private boolean canCancel() {
-        return !Jenkins.getInstance().isUseSecurity() || getRun().getParent().hasPermission(Job.CANCEL);
+        return !Jenkins.getActiveInstance().isUseSecurity() || getRun().getParent().hasPermission(Job.CANCEL);
     }
 
     private boolean canSubmit() {
@@ -298,7 +298,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String submitter = input.getSubmitter();
         if (submitter==null)
             return getRun().getParent().hasPermission(Job.BUILD);
-        if (!Jenkins.getInstance().isUseSecurity() || Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.getActiveInstance().isUseSecurity() || Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
         final Set<String> submitters = Sets.newHashSet(submitter.split(","));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -298,7 +298,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String submitter = input.getSubmitter();
         if (submitter==null)
             return getRun().getParent().hasPermission(Job.BUILD);
-        if (!Jenkins.getActiveInstance().isUseSecurity() || Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.getActiveInstance().isUseSecurity() || Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
         final Set<String> submitters = Sets.newHashSet(submitter.split(","));

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -207,7 +207,9 @@ public class InputStepTest extends Assert {
                 // is listed as the submitter.
                         grant(Jenkins.READ, Job.READ).everywhere().to("bob").
                 // Give "charlie" basic privs.  That's normally not enough to Job.CANCEL, and isn't listed as submiter.
-                        grant(Jenkins.READ, Job.READ).everywhere().to("charlie"));
+                        grant(Jenkins.READ, Job.READ).everywhere().to("charlie").
+                // Add an admin user that should be able to approve the job regardless)
+                        grant(Jenkins.ADMINISTER).everywhere().to("admin"));
 
         final WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
         foo.setDefinition(new CpsFlowDefinition("input id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'alice,bob'", true));
@@ -215,6 +217,7 @@ public class InputStepTest extends Assert {
         runAndAbort(webClient, foo, "alice", true);   // alice should work coz she's declared as 'submitter'
         runAndAbort(webClient, foo, "bob", true);    // bob should work coz he's declared as 'submitter'
         runAndAbort(webClient, foo, "charlie", false); // charlie shouldn't work coz he's not declared as 'submitter' and doesn't have Job.CANCEL privs
+        runAndContinue(webClient, foo, "admin", true); // admin should work because... they can do anything
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-48998](https://issues.jenkins-ci.org/browse/JENKINS-48998)

For now I'm just granting to ADMINs - technically people with Item.CONFIGURE could bypass the Input (by Replay or changing the pipeline type).  It feels a bit wrong to encourage that though, if they're explicitly not supposed to be able to approve (by setting restricted submitters list for the InputStep). Admins on the other hand imply a high degree of trust implicitly.

@reviewbybees 