### PR TITLE
Do a case insensitive search for submitter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -301,8 +301,8 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         if (!Jenkins.getActiveInstance().isUseSecurity() || Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
-        final Set<String> submitters = Sets.newHashSet(submitter.split(","));
-        if (submitters.contains(a.getName()))
+        final Set<String> submitters = Sets.newHashSet(submitter.toLowerCase().split(","));
+        if (submitters.contains(a.getName().toLowerCase()))
             return true;
         for (GrantedAuthority ga : a.getAuthorities()) {
             if (submitters.contains(ga.getAuthority()))


### PR DESCRIPTION
Perform a case insensitive lookup for the username who can approve a waiting input step. This seems to be case with most authentication systems (in fact all).