### PR TITLE
[WIP] [JENKINS-55181] Input submitter parameter should use the current IdStrategy to match against current user

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -36,6 +36,7 @@ import hudson.model.queue.QueueTaskFuture;
 
 import java.util.List;
 
+import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -212,9 +213,10 @@ public class InputStepTest extends Assert {
                         grant(Jenkins.ADMINISTER).everywhere().to("admin"));
 
         final WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
-        foo.setDefinition(new CpsFlowDefinition("input id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'alice,bob'", true));
+        foo.setDefinition(new CpsFlowDefinition("input id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'alice,BoB'", true));
 
         runAndAbort(webClient, foo, "alice", true);   // alice should work coz she's declared as 'submitter'
+        assertEquals(IdStrategy.CASE_INSENSITIVE, j.jenkins.getSecurityRealm().getUserIdStrategy());
         runAndAbort(webClient, foo, "bob", true);    // bob should work coz he's declared as 'submitter'
         runAndContinue(webClient, foo, "bob", true);    // bob should work coz he's declared as 'submitter'
         runAndAbort(webClient, foo, "charlie", false); // charlie shouldn't work coz he's not declared as 'submitter' and doesn't have Job.CANCEL privs

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -216,6 +216,7 @@ public class InputStepTest extends Assert {
 
         runAndAbort(webClient, foo, "alice", true);   // alice should work coz she's declared as 'submitter'
         runAndAbort(webClient, foo, "bob", true);    // bob should work coz he's declared as 'submitter'
+        runAndContinue(webClient, foo, "bob", true);    // bob should work coz he's declared as 'submitter'
         runAndAbort(webClient, foo, "charlie", false); // charlie shouldn't work coz he's not declared as 'submitter' and doesn't have Job.CANCEL privs
         runAndContinue(webClient, foo, "admin", true); // admin should work because... they can do anything
     }


### PR DESCRIPTION
[JENKINS-55181](https://issues.jenkins-ci.org/browse/JENKINS-55181)

1. [x] Reproducer commit, expected to fail https://github.com/jenkinsci/pipeline-input-step-plugin/pull/26/commits/d911e810d767eba044be6de9c9cf9314a31b74e3 (on L220)
1. [ ] Fix commit 
