### PR TITLE
[JEP-305] Incrementalify

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.3'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
         <version>3.28</version>
         <relativePath />
     </parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-input-step</artifactId>
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.26</version>
+        <version>3.28</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-input-step</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Input Step</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Input+Step+Plugin</url>
@@ -23,7 +23,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>${scmTag}</tag>
   </scm>
     <repositories>
         <repository>
@@ -38,7 +38,10 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>1.642.4</jenkins.version>
+        <revision>2.9</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
     </properties>
     <dependencies>
         <dependency>
@@ -79,6 +82,12 @@
             <artifactId>structs</artifactId>
             <version>1.5</version>
             <scope>test</scope>
+            <exclusions> <!-- coming from the core - RequireUpperBoundDeps fix -->
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,14 +80,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.5</version>
+            <version>1.17</version>
             <scope>test</scope>
-            <exclusions> <!-- coming from the core - RequireUpperBoundDeps fix -->
-                <exclusion>
-                    <groupId>org.jenkins-ci</groupId>
-                    <artifactId>annotation-indexer</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
See https://github.com/jenkinsci/incrementals-tools

This would be cool to be able to generate _Incrementals_ release on each `master` merge, or for PRs, like it should happen for this one already.

* RequireUpperBoundDeps fix induced by the parent pom bump
* Bump to Java 8 / Jenkins 2.60.3 as minimum version
  (I had a local test failure on older core, and I do not think it still
  makes sense to spend time even trying to understand why it fails on
  Java 7 and Jenkins 1.642.4).