### PR TITLE
Trim submitter name before comparison

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -25,6 +25,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -328,7 +329,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
      */
     private boolean isMemberOf(String userId, Set<String> submitters, IdStrategy idStrategy) {
         for (String submitter : submitters) {
-            if (idStrategy.equals(userId, submitter)) {
+            if (idStrategy.equals(userId, StringUtils.trim(submitter))) {
                 return true;
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
@@ -1,4 +1,4 @@
 <div>
     User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, separated by ','.
-    If you configure "alice, bob", will match with "alice" but not with "bob". You need to remove all the white spaces.
+    Spaces will be trimmed. This means that "alice, bob, blah " will be equivalent to "alice,bob,blah".
 </div>


### PR DESCRIPTION
Trivial improvement to make the step more user-friendly given people are used to put spaces after commas.