### PR TITLE
[JENKINS-47699] Support user-scoped credentials in input step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.29</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.17</version>
@@ -100,6 +106,17 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.50</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.2.1-rc620.6cca6d311692</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials-binding</artifactId>
+            <version>1.18</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This uses the [CredentialsParameterAction prototype](https://github.com/jenkinsci/credentials-plugin/pull/119) approach. See [JENKINS-47699](https://issues.jenkins-ci.org/browse/JENKINS-47699).