### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -16,6 +16,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.SecurityRealm;
 import hudson.security.Permission;
 import hudson.util.HttpResponses;
@@ -96,11 +97,9 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         // JENKINS-37154: we might be inside the VM thread, so do not do anything which might block on the VM thread
         Timer.get().submit(new Runnable() {
             @Override public void run() {
-                ACL.impersonate(ACL.SYSTEM, new Runnable() {
-                    @Override public void run() {
-                        doAbort();
-                    }
-                });
+                try (ACLContext context = ACL.as(ACL.SYSTEM)) {
+                    doAbort();
+                }
             }
         });
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -285,7 +285,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     }
 
     private boolean canCancel() {
-        return !Jenkins.getActiveInstance().isUseSecurity() || getRun().getParent().hasPermission(Job.CANCEL);
+        return !Jenkins.get().isUseSecurity() || getRun().getParent().hasPermission(Job.CANCEL);
     }
 
     private boolean canSubmit() {
@@ -300,11 +300,11 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String submitter = input.getSubmitter();
         if (submitter==null)
             return getRun().getParent().hasPermission(Job.BUILD);
-        if (!Jenkins.getActiveInstance().isUseSecurity() || Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().isUseSecurity() || Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
         final Set<String> submitters = Sets.newHashSet(submitter.split(","));
-        final SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
+        final SecurityRealm securityRealm = Jenkins.get().getSecurityRealm();
         if (isMemberOf(a.getName(), submitters, securityRealm.getUserIdStrategy()))
             return true;
         for (GrantedAuthority ga : a.getAuthorities()) {


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`ACL.impersonate(org.acegisecurity.Authentication, java.lang.Runnable)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#impersonate-org.acegisecurity.Authentication-java.lang.Runnable-) states: "use try with resources and [`as(Authentication)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#as-org.acegisecurity.Authentication-)".
- The documentation for [`Jenkins.getActiveInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getActiveInstance--) states: "This is a verbose historical alias for [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--)."

Accordingly, I replaced any usages of `ACL.impersonate` with usages of try-with-resources and `ACL.as`, boolean and I replaced any calls to `Jenkins.getActiveInstance()` with calls to `Jenkins.get()`.