### PR TITLE
Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>3.48</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-input-step</artifactId>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.32 to 3.48.

See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.32...plugin-3.48).