### PR TITLE
[JENKINS-60354] Mark thrown FlowInterruptedException as an actual interruption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,14 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
+        <workflow-step-api-plugin.version>2.22-rc550.2870bd01d2ff</workflow-step-api-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.138.1</version>
+                <artifactId>bom-2.138.x</artifactId>
+                <version>4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,6 +58,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -99,6 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -228,7 +228,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     public HttpResponse doAbort() {
         preAbortCheck();
 
-        FlowInterruptedException e = new FlowInterruptedException(Result.ABORTED, new Rejection(User.current()));
+        FlowInterruptedException e = new FlowInterruptedException(Result.ABORTED, true, new Rejection(User.current()));
         outcome = new Outcome(null,e);
         postSettlement();
         getContext().onFailure(e);


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.