### PR TITLE
Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Input Step</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Input+Step+Plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-input-step</artifactId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -339,6 +339,8 @@ public class InputStepTest extends Assert {
         } catch (Exception e) {
             assertFalse(expectAbortOk);
             j.waitForMessage("Yes or Abort", run);
+            run.doStop();
+            j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
         }
     }
 
@@ -368,6 +370,8 @@ public class InputStepTest extends Assert {
         } catch (Exception e) {
             assertFalse(expectContinueOk);
             j.waitForMessage("Yes or Abort", run);
+            run.doStop();
+            j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
         }
     }
 


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.48 to 3.54.

See [the changelog](https://github.com/jenkinsci/plugin-pom/releases) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.48...plugin-3.54).