### PR TITLE
Flake in InputStepTest.test_submitter_parameter

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -254,7 +254,7 @@ public class InputStepTest extends Assert {
         // get the build going, and wait until workflow pauses
         QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();
-        j.waitForMessage("input", b);
+        j.waitForMessage("Input requested", b);
 
         // make sure we are pausing at the right state that reflects what we wrote in the program
         InputAction a = b.getAction(InputAction.class);
@@ -292,7 +292,7 @@ public class InputStepTest extends Assert {
         // get the build going, and wait until workflow pauses
         QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();
-        j.waitForMessage("input", b);
+        j.waitForMessage("Input requested", b);
 
         // make sure we are pausing at the right state that reflects what we wrote in the program
         InputAction a = b.getAction(InputAction.class);


### PR DESCRIPTION
Noticed in PCT and also observed locally:

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.support.steps.input.InputStepTest.test_submitter_parameter(InputStepTest.java:261)
```

I think the test found

```
[Pipeline] input
```

and proceeded, when the step was not yet fully initialized.

Amends #8.