### PR TITLE
[JENKINS-63516] Make password parameters work with the input step in Jenkins 2.236+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin()
+buildPlugin(useAci: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'windows', jdk: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.236' ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
+        <useBeta>true</useBeta>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.6</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-input-step</artifactId>
@@ -39,21 +39,25 @@
     <properties>
         <revision>2.12</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.138.x</artifactId>
-                <version>3</version>
+                <artifactId>bom-2.176.x</artifactId>
+                <version>11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
@@ -69,7 +73,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -92,11 +95,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <classifier>tests</classifier>
@@ -115,7 +113,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
-            <version>1.18</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -8,10 +8,10 @@ import hudson.model.PasswordParameterDefinition;
 import hudson.util.Secret;
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
@@ -224,7 +224,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
          * Copy a map, replacing the entry with the specified key if it matches the specified type.
          */
         private static <T> Map<String, Object> copyMapReplacingEntry(Map<String, ?> map, String oldKey, String newKey, Class<T> requiredValueType, Function<T, Object> replacer) {
-            Map<String, Object> newMap = new HashMap<>();
+            Map<String, Object> newMap = new TreeMap<>();
             for (Map.Entry<String, ?> entry : map.entrySet()) {
                 if (entry.getKey().equals(oldKey) && requiredValueType.isInstance(entry.getValue())) {
                     newMap.put(newKey, replacer.apply(requiredValueType.cast(entry.getValue())));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -186,7 +186,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
                         if (parameter instanceof UninstantiatedDescribable) {
                             UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
                             if (ud.getSymbol().equals("password")) {
-                                Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "defaultValue", "defaultValueAsString", String.class, Secret::fromString);
+                                Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "defaultValue", "defaultValueAsSecret", String.class, Secret::fromString);
                                 return ud.withArguments(newArguments);
                             }
                         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -4,18 +4,27 @@ import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.ParameterDefinition;
+import hudson.model.PasswordParameterDefinition;
+import hudson.util.Secret;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
+import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 /**
  * {@link Step} that pauses for human input.
@@ -148,7 +157,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
     }
 
     @Extension
-    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl implements CustomDescribableModel {
 
         public DescriptorImpl() {
             super(InputStepExecution.class);
@@ -162,6 +171,68 @@ public class InputStep extends AbstractStepImpl implements Serializable {
         @Override
         public String getDisplayName() {
             return Messages.wait_for_interactive_input();
+        }
+
+        /**
+         * Compatibility hack for JENKINS-63516.
+         */
+        @Override
+        public Map<String, Object> customInstantiate(Map<String, Object> map) {
+            if (DescribableModel.of(PasswordParameterDefinition.class).getParameter("defaultValue") != null) {
+                return map;
+            }
+            return copyMapReplacingEntry(map, "parameters", "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "defaultValue", "defaultValueAsString", String.class, Secret::fromString);
+                                return ud.withArguments(newArguments);
+                            }
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
+            );
+        }
+
+        /**
+         * Compatibility hack for JENKINS-63516.
+         */
+        @Override
+        public UninstantiatedDescribable customUninstantiate(UninstantiatedDescribable step) {
+            if (DescribableModel.of(PasswordParameterDefinition.class).getParameter("defaultValue") != null) {
+                return step;
+            }
+            Map<String, Object> newStepArgs = copyMapReplacingEntry(step.getArguments(), "parameters", "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newParamArgs = copyMapReplacingEntry(ud.getArguments(), "defaultValueAsSecret", "defaultValue", Secret.class, Secret::getPlainText);
+                                return ud.withArguments(newParamArgs);
+                            }
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
+            );
+            return step.withArguments(newStepArgs);
+        }
+
+        /**
+         * Copy a map, replacing the entry with the specified key if it matches the specified type.
+         */
+        private static <T> Map<String, Object> copyMapReplacingEntry(Map<String, ?> map, String oldKey, String newKey, Class<T> requiredValueType, Function<T, Object> replacer) {
+            Map<String, Object> newMap = new HashMap<>();
+            for (Map.Entry<String, ?> entry : map.entrySet()) {
+                if (entry.getKey().equals(oldKey) && requiredValueType.isInstance(entry.getValue())) {
+                    newMap.put(newKey, replacer.apply(requiredValueType.cast(entry.getValue())));
+                } else {
+                    newMap.put(entry.getKey(), entry.getValue());
+                }
+            }
+            return newMap;
         }
     }
 }


### PR DESCRIPTION
See [JENKINS-63516](https://issues.jenkins-ci.org/browse/JENKINS-63516). The fix in this PR is more or less copied from https://github.com/jenkinsci/pipeline-build-step-plugin/pull/46.

Both actual step usage and the snippet generator are fixed by this PR.