### PR TITLE
Fix documentation typo for options available in stage view

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help.html
@@ -1,7 +1,7 @@
 <div>
     <p>
     This step pauses Pipeline execution and allows the user to interact and control the flow of the build.
-    Only a basic "process" or "abort" option is provided in the stage view.
+    Only a basic "proceed" or "abort" option is provided in the stage view.
     </p>
     <p>
     You can optionally request information back, hence the name of the step. 


### PR DESCRIPTION
Changed "process" to "proceed" in the plugin documentation, since it is what appears in the UI.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
