### PR TITLE
[JENKINS-66798] check null for ud.getSymbol()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -185,7 +185,7 @@ public class InputStep extends AbstractStepImpl implements Serializable {
                     .map(parameter -> {
                         if (parameter instanceof UninstantiatedDescribable) {
                             UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
-                            if (ud.getSymbol().equals("password")) {
+                            if (null != ud.getSymbol() && ud.getSymbol().equals("password")) {
                                 Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "defaultValue", "defaultValueAsSecret", String.class, Secret::fromString);
                                 return ud.withArguments(newArguments);
                             }


### PR DESCRIPTION
PR created to fix the following issue: https://issues.jenkins.io/browse/JENKINS-66798

Null check for the following:

`if (null != ud.getSymbol() && ud.getSymbol().equals("password")) {...}`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


