### PR TITLE
Fixed JENKINS-41015, question marks needs encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.308</jenkins.version>
+        <jenkins.version>2.319.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.308.x</artifactId>
+                <artifactId>bom-2.319.x</artifactId>
                 <version>1289.v5c4b_1c43511b_</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.361</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
+                <artifactId>bom-2.361.x</artifactId>
                 <version>1289.v5c4b_1c43511b_</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361</jenkins.version>
+        <jenkins.version>2.308</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
+                <artifactId>bom-2.308.x</artifactId>
                 <version>1289.v5c4b_1c43511b_</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -110,7 +110,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
         //JENKINS-40594 submitterParameter does not work without at least one actual parameter
         if (input.getParameters().isEmpty() && input.getSubmitterParameter() == null) {
-            String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
+            String thisUrl = baseUrl + Util.fullEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),
                     POSTHyperlinkNote.encodeTo(thisUrl + "abort", "Abort"));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -110,7 +110,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
         //JENKINS-40594 submitterParameter does not work without at least one actual parameter
         if (input.getParameters().isEmpty() && input.getSubmitterParameter() == null) {
-            String thisUrl = baseUrl + Util.fullEncode(getId()) + '/';
+            String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),
                     POSTHyperlinkNote.encodeTo(thisUrl + "abort", "Abort"));


### PR DESCRIPTION
The issue is that Hudson's til function `rawEncode(str)` does not encode `?` which causes stage names like `"Deploy or stop?"` to fail because it generates a URL with the stage name and raw question mark in it.

[The documentation for Hudson is incorrect](https://javadoc.jenkins.io/hudson/Util.html#rawEncode(java.lang.String)), in that it states that it encodes stuff like this:
![Screen Shot 2022-07-28 at 14 18 53](https://user-images.githubusercontent.com/895369/181639254-8617d695-5ae8-40eb-a3e9-5ee3aafb1cfc.jpg)

But if you read the source, it's clear that it considered `?` as safe, which it isn't in this context.

To use `fullEncode()` it was necessary to upgrade to 2.308+, which means we need to upgrade to 2.319.x since that's what's included in the BOM version for [v1289](https://github.com/jenkinsci/bom/tree/1289.v5c4b_1c43511b_).