### PR TITLE
Issue #69889: Describe identifiers more clearly in help and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Input Example with `Message Parameter`:
   input 'Proceed or Abort'
 
 
-Input Example with `Custom ID`:
-Every input step has an unique ID. It is used in the generated URL to proceed or abort.
+Input Example with `Custom identifier`:
+Every input step has an unique identifier. It is used in the generated URL to proceed or abort.
 
-A specific ID could be used, for example, to mechanically respond to the input from some external process/tool.
+A specific identifier could be used, for example, to mechanically respond to the input from some external process/tool.
 
    input id: '2', message: 'input-message'
 
@@ -23,14 +23,14 @@ Input Example with `OK Button Caption`(Optional):
    input message: 'input-message', ok: 'OK'
 
 Input Example with `Allowed Submitter`:
-User IDs and/or external group names of person or people permitted to respond to the input, separated by ','. Spaces will be trimmed automatically, so "Alice, Bob, Charles" is the same as "Alice,Bob,Charles".
+Usernames and/or external group names of those permitted to respond to the input, separated by ','. Spaces will be trimmed automatically, so "Alice, Bob, Charles" is the same as "Alice,Bob,Charles".
 Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter.
 
    input message: '', submitter: 'jenkins-user, jenkins-user2'
 
 Input Example with Parameter to store the `Approving Submitter`:
 
-If specified, this is the name of the return value that will contain the ID of the user that approves this input. The return value will be handled in a fashion similar to the parameters value.
+If specified, this is the name of the return value that will contain the username of the user that approves this input. The return value will be handled in a fashion similar to the parameters value.
 
    input message: 'input-message', submitter: 'jenkins-submitter, jenkins-submitter2', submitterParameter: 'approvers-id-to-be-stored'
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-id.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-id.html
@@ -1,6 +1,6 @@
 <p>
-    Every <code>input</code> step has an unique ID. It is used in the generated URL to proceed or abort.
+    Every <code>input</code> step has an unique identifier. It is used in the generated URL to proceed or abort.
 </p>
 <p>
-    A specific ID could be used, for example, to mechanically respond to the input from some external process/tool.
+    A specific identifier could be used, for example, to mechanically respond to the input from some external process/tool.
 </p>


### PR DESCRIPTION
Guidance from @jtnord was that the acronym "ID" would be better expressed as the word "identifier" since it could be confused with many different forms of "ID". 
In this PR, I have changed references of ID to identifier/id.

LINK: https://issues.jenkins.io/browse/JENKINS-69889

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


