### PR TITLE
Avoid "IOException: cannot find current thread" when submitting an input step that ends a `CpsThread`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -200,6 +200,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
      */
     @RequirePOST
     public HttpResponse doSubmit(StaplerRequest request) throws IOException, ServletException, InterruptedException {
+        Run<?, ?> run = getRun();
         if (request.getParameter("proceed")!=null) {
             doProceed(request);
         } else {
@@ -207,7 +208,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         }
 
         // go back to the Run console page
-        return HttpResponses.redirectTo(ConsoleUrlProvider.getRedirectUrl(getRun()));
+        return HttpResponses.redirectTo(ConsoleUrlProvider.getRedirectUrl(run));
     }
 
     /**


### PR DESCRIPTION
Fixes a timing issue in #145 - whenever the `input` step was the last part of a `CpsThread`, it was possible that the thread would be removed from the thread group before we called `StepContext.get`, causing `CpsThreadGroup.doGet` to throw an exception.

https://github.com/jenkinsci/workflow-support-plugin/pull/252 would make this kind of change obsolete, but this change is minimal and cannot affect other plugins, so I think worth considering as a hotfix.  

### Testing done

I tested this manually using a test that failed reliably after https://github.com/jenkinsci/workflow-support-plugin/pull/252. With this change, it passes reliably.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
