### PR TITLE
Fix incorrect abort cause

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -134,16 +134,18 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
 
     @Override
     public void stop(Throwable cause) throws Exception {
+        outcome = new Outcome(null,cause);
         // JENKINS-37154: we might be inside the VM thread, so do not do anything which might block on the VM thread
         Timer.get().submit(new Runnable() {
             @Override public void run() {
                 try (ACLContext context = ACL.as(ACL.SYSTEM)) {
-                    doAbort();
+                   postSettlement();
                 } catch (IOException | InterruptedException x) {
                     LOGGER.log(Level.WARNING, "failed to abort " + getContext(), x);
                 }
             }
         });
+        super.stop(cause);
     }
 
     @Exported


### PR DESCRIPTION

Previous commit https://github.com/jenkinsci/pipeline-input-step-plugin/pull/159 (I cancelled that as had spotless issues :sweat:). I have actioned the feedback from that PR for inclusion in this PR.

There is a bug with the build result when a build is aborted. This seems to be an issue with the cause not being passed through to `doAbort()` [here](https://github.com/jenkinsci/pipeline-input-step-plugin/blob/b07d21da1afb043a5eeedec8d575a13c04773702/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java#L135-L147).

Reproduction steps to reproduce bug:
- make a pipeline job with the script being 'input 'proceed?', set it to abort previous builds
- run the job once (do not click on proceed, leave it running/waiting)
- run the job again
- Check the abort message on the first build. It should be `NOT_BUILT` since that is what we passed to `Executor.interrupt`, but instead it says `ABORTED` as the cancel cause is not being used.

Testing done
Manual testing done as well as adding a new test case.

Before:
![Screenshot from 2024-04-16 17-24-04](https://github.com/jenkinsci/pipeline-input-step-plugin/assets/55280278/8d53a95d-9b24-488c-ba37-f4e52d08df2a)
![Screenshot from 2024-04-16 17-24-34](https://github.com/jenkinsci/pipeline-input-step-plugin/assets/55280278/d4c05d31-58f2-4f62-b6cf-93df9ff1dc3f)

After:
![Screenshot from 2024-04-16 17-22-04](https://github.com/jenkinsci/pipeline-input-step-plugin/assets/55280278/66bf9b9c-45ed-4b0b-a454-e4ece47d6aa3)
![Screenshot from 2024-04-16 17-27-09](https://github.com/jenkinsci/pipeline-input-step-plugin/assets/55280278/6058a180-25e8-44c5-933d-be04c10e4211)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

