### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.440</jenkins.version>
+        <jenkins.version>2.440.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

[Installation statistics](https://stats.jenkins.io/pluginversions/pipeline-input-step.html) show that 90% of the installations of 495.ve9c153f6067b_ are already running Jenkins 2.440.3 or newer.

["Choosing a Jenkins baseline"](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends Jenkins 2.440.3 as one of the versions, rather than 2.440.

Includes pull requests:

* #164
* #167

Supersedes pull requests:

* #157

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
