### PR TITLE
Allow custom "abort" text

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A specific identifier could be used, for example, to mechanically respond to the
    input id: '2', message: 'input-message'
 
 
-Input Example with `OK Button Caption`(Optional):
+Input Example with `Cancel Button Caption` and `OK Button Caption` (Optional):
 
-   input message: 'input-message', ok: 'OK'
+   input message: 'input-message', cancel: 'Cancel', ok: 'OK'
 
 Input Example with `Allowed Submitter`:
 Usernames and/or external group names of those permitted to respond to the input, separated by ','. Spaces will be trimmed automatically, so "Alice, Bob, Charles" is the same as "Alice,Bob,Charles".

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStep.java
@@ -77,6 +77,11 @@ public class InputStep extends AbstractStepImpl implements Serializable {
     private List<ParameterDefinition> parameters = Collections.emptyList();
 
     /**
+     * Caption of the Cancel button.
+     */
+    private String cancel;
+
+    /**
      * Caption of the OK button.
      */
     private String ok;
@@ -131,6 +136,18 @@ public class InputStep extends AbstractStepImpl implements Serializable {
         if ('a'<=ch && ch<='z')
             id = ((char)(ch-'a'+'A')) + id.substring(1);
         return id;
+    }
+
+    /**
+     * Caption of the Cancel button.
+     */
+    @Exported
+    public String getCancel() {
+        return cancel!=null ? cancel : Messages.abort();
+    }
+
+    @DataBoundSetter public void setCancel(String cancel) {
+        this.cancel = Util.fixEmptyAndTrim(cancel);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -123,7 +123,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
             String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),
-                    POSTHyperlinkNote.encodeTo(thisUrl + "abort", "Abort"));
+                    POSTHyperlinkNote.encodeTo(thisUrl + "abort", input.getCancel()));
         } else {
             // TODO listener.hyperlink(…) does not work; why?
             // TODO would be even cooler to embed the parameter form right in the build log (hiding it after submission)

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/config.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
         <f:entry field="id" title="${%Custom ID}">
             <f:textbox/>
         </f:entry>
+        <f:entry field="cancel" title="${%Cancel Button Caption}">
+            <f:textbox/>
+        </f:entry>
         <f:entry field="ok" title="${%OK Button Caption}">
             <f:textbox/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-cancel.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-cancel.html
@@ -1,0 +1,12 @@
+<p>
+    You can customize the text for the "abort" button to better match the context.
+</p>
+
+<p>Usage: <code>input message: 'Would you like to skip the next step?', ok: "Yes", cancel: "No, run anyway"</code></p>
+
+<p>Which will look like:
+<pre>
+        Would you like to skip the next step?
+        Yes or No, run anyway
+    </pre>
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-ok.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-ok.html
@@ -1,0 +1,12 @@
+<p>
+    You can customize the text for the "proceed" button to better match the context.
+</p>
+
+<p>Usage: <code>input message: 'Do you approve?', ok: "Yes"</code></p>
+
+<p>Which will look like:
+<pre>
+        Do you approve?
+        Yes or Abort
+    </pre>
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution/index.jelly
@@ -27,7 +27,7 @@
       </j:forEach>
       <f:block>
         <f:submit value="${it.input.ok}" name="proceed"/>
-        <f:submit value="${%Abort}" name="abort"/>
+        <f:submit value="${it.input.cancel}" name="abort"/>
       </f:block>
     </f:form>
   </j:if>


### PR DESCRIPTION
Allow customizing the "Abort" text to better match the context, just like with "Proceed"

This supersedes #54 

Solves [JENKINS-66820](https://issues.jenkins.io/browse/JENKINS-66820)

### Testing done

Extended the existing automated tests

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
