### PR TITLE
[JENKINS-75384] updated user doc on input respond

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Input Example with `Cancel Button Caption` and `OK Button Caption` (Optional):
 
 Input Example with `Allowed Submitter`:
 Usernames and/or external group names of those permitted to respond to the input, separated by ','. Spaces will be trimmed automatically, so "Alice, Bob, Charles" is the same as "Alice,Bob,Charles".
-Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. And users with **cancel** permissions may also respond with 'Abort' to the input. 
+Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. Users with [**Job/cancel** permission](https://www.jenkins.io/doc/book/security/access-control/permissions/#job-permissions) may also respond with 'Abort' to the input.
 
    input message: '', submitter: 'jenkins-user, jenkins-user2'
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Input Example with `Cancel Button Caption` and `OK Button Caption` (Optional):
 
 Input Example with `Allowed Submitter`:
 Usernames and/or external group names of those permitted to respond to the input, separated by ','. Spaces will be trimmed automatically, so "Alice, Bob, Charles" is the same as "Alice,Bob,Charles".
-Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter.
+Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. And users with **cancel** permissions may also respond with 'Abort' to the input. 
 
    input message: '', submitter: 'jenkins-user, jenkins-user2'
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
@@ -1,5 +1,5 @@
 <div>
     User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, separated by ','.
     Spaces will be trimmed. This means that "alice, bob, blah " is the same as "alice,bob,blah".<br>
-    <strong>Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter.</strong>
+    <strong>Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. And users with cancel permissions may also respond with 'Abort' to the input.</strong>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/input/InputStep/help-submitter.html
@@ -1,5 +1,5 @@
 <div>
     User IDs and/or <em>external</em> group names of person or people permitted to respond to the input, separated by ','.
     Spaces will be trimmed. This means that "alice, bob, blah " is the same as "alice,bob,blah".<br>
-    <strong>Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. And users with cancel permissions may also respond with 'Abort' to the input.</strong>
+    <strong>Note: Jenkins administrators are able to respond to the input regardless of the value of this parameter. Users with <a href="https://www.jenkins.io/doc/book/security/access-control/permissions/#job-permissions">Job/cancel permission</a> may also respond with 'Abort' to the input.</strong>
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did - I noticed that users with cancel permissions can respond with 'Abort' to the input, regardless of whether they are an admin or not. I have added that info in necessary doc. Details are shared in the [JENKINS-75384](https://issues.jenkins.io/browse/JENKINS-75384)
- [x] Link to relevant issues in GitHub or Jira [JENKINS-75384](https://issues.jenkins.io/browse/JENKINS-75384)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
