### PR TITLE
[JENKINS-40594] Handle submitterParameter in proceedEmpty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -121,8 +121,7 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
         node.addAction(new PauseAction("Input"));
 
         String baseUrl = '/' + run.getUrl() + getPauseAction().getUrlName() + '/';
-        //JENKINS-40594 submitterParameter does not work without at least one actual parameter
-        if (input.getParameters().isEmpty() && input.getSubmitterParameter() == null) {
+        if (input.getParameters().isEmpty()) {
             String thisUrl = baseUrl + Util.rawEncode(getId()) + '/';
             listener.getLogger().printf("%s%n%s or %s%n", input.getMessage(),
                     POSTHyperlinkNote.encodeTo(thisUrl + "proceedEmpty", input.getOk()),
@@ -288,7 +287,18 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     public HttpResponse doProceedEmpty() throws IOException, InterruptedException {
         preSubmissionCheck();
 
-        return proceed(null);
+        Map<String, Object> mapResult = handleSubmitterParameter();
+        return proceed(mapResult);
+    }
+
+    private Map<String, Object> handleSubmitterParameter() {
+        String valueName = input.getSubmitterParameter();
+        String userId = Jenkins.getAuthentication2().getName();
+        Map<String,Object> mapResult = new HashMap<>();
+        if (valueName != null && !valueName.isEmpty()) {
+            mapResult.put(valueName, userId);
+        }
+        return mapResult;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepExecution.java
@@ -294,11 +294,10 @@ public class InputStepExecution extends AbstractStepExecutionImpl implements Mod
     private Map<String, Object> handleSubmitterParameter() {
         String valueName = input.getSubmitterParameter();
         String userId = Jenkins.getAuthentication2().getName();
-        Map<String,Object> mapResult = new HashMap<>();
         if (valueName != null && !valueName.isEmpty()) {
-            mapResult.put(valueName, userId);
+            return Map.of(valueName, userId);
         }
-        return mapResult;
+        return null;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -331,7 +331,7 @@ public class InputStepTest {
             wc.login("alice");
             HtmlPage console = wc.getPage(b, "console");
             HtmlElement proceedLink = console.getFirstByXPath("//a[text()='Purchase icecream']");
-            proceedLink.click();
+            HtmlElementUtil.click(proceedLink);
         }
         assertEquals(0, a.getExecutions().size());
         q.get();

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/input/InputStepTest.java
@@ -33,6 +33,7 @@ import org.htmlunit.ElementNotFoundException;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlElementUtil;
 import org.htmlunit.html.HtmlFileInput;
 import org.htmlunit.html.HtmlForm;
@@ -277,7 +278,7 @@ public class InputStepTest {
         // get the build going, and wait until workflow pauses
         QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();
-        j.waitForMessage("Input requested", b);
+        j.waitForMessage("Purchase icecream", b);
 
         // make sure we are pausing at the right state that reflects what we wrote in the program
         InputAction a = b.getAction(InputAction.class);
@@ -288,12 +289,13 @@ public class InputStepTest {
         assertEquals("alice,bob", is.getInput().getSubmitter());
 
         // submit the input, and run workflow to the completion
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.login("alice");
-        HtmlPage console_page = wc.getPage(b, "console");
-        assertFalse(console_page.asXml().contains("proceedEmpty"));
-        HtmlPage p = wc.getPage(b, a.getUrlName());
-        j.submit(p.getFormByName(is.getId()), "proceed");
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            wc.login("alice");
+            HtmlPage console = wc.getPage(b, "console");
+            HtmlElement proceedLink = console.getFirstByXPath("//a[text()='Purchase icecream']");
+            HtmlElementUtil.click(proceedLink);
+        }
+
         assertEquals(0, a.getExecutions().size());
         q.get();
 
@@ -315,7 +317,7 @@ public class InputStepTest {
         // get the build going, and wait until workflow pauses
         QueueTaskFuture<WorkflowRun> q = foo.scheduleBuild2(0);
         WorkflowRun b = q.getStartCondition().get();
-        j.waitForMessage("Input requested", b);
+        j.waitForMessage("Purchase icecream", b);
 
         // make sure we are pausing at the right state that reflects what we wrote in the program
         InputAction a = b.getAction(InputAction.class);
@@ -325,10 +327,12 @@ public class InputStepTest {
         assertEquals("Do you want chocolate?", is.getInput().getMessage());
 
         // submit the input, and run workflow to the completion
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.login("alice");
-        HtmlPage p = wc.getPage(b, a.getUrlName());
-        j.submit(p.getFormByName(is.getId()), "proceed");
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            wc.login("alice");
+            HtmlPage console = wc.getPage(b, "console");
+            HtmlElement proceedLink = console.getFirstByXPath("//a[text()='Purchase icecream']");
+            proceedLink.click();
+        }
         assertEquals(0, a.getExecutions().size());
         q.get();
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/920

### Testing done

In console:

<img width="420" height="277" alt="image" src="https://github.com/user-attachments/assets/50e54455-8373-4661-8143-aa2ede2bd991" />

It now allows inline approval for submitter and it correctly echoes it:

```groovy
node {
    stage("Test Input") {
        String approver = input(
           message: "This an input test",
           submitter: "lmoodley",
           submitterParameter: "USER"
         )    
        println("${approver}")
    }
}
```

Also tested in pipeline graph view and it works fine there too.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
